### PR TITLE
Don't overwrite NC Lode API components

### DIFF
--- a/adze.lua
+++ b/adze.lua
@@ -12,7 +12,7 @@ local function addzecaps(lv)
 			cracky = lv - 2
 		})
 end
-nodecore.register_lode("adze", {
+nodecore.register_adamant("adze", {
 		type = "tool",
 		description = "## Adamant Adze",
 		inventory_image = modname .. "_#.png^[mask:nc_lode_adze.png",

--- a/metallurgy.lua
+++ b/metallurgy.lua
@@ -1,6 +1,6 @@
 -- LUALOCALS < ---------------------------------------------------------
-local ItemStack, minetest, nodecore, pairs, type
-    = ItemStack, minetest, nodecore, pairs, type
+local minetest, nodecore, pairs, type
+    = minetest, nodecore, pairs, type
 -- LUALOCALS > ---------------------------------------------------------
 
 local modname = minetest.get_current_modname()
@@ -24,7 +24,7 @@ local tempers = {
 	}
 }
 
-function nodecore.register_lode(shape, rawdef)
+function nodecore.register_adamant(shape, rawdef)
 	rawdef.groups = rawdef.groups or {}
 	for _, temper in pairs(tempers) do
 		local def = nodecore.underride({}, rawdef)
@@ -81,7 +81,7 @@ function nodecore.register_lode(shape, rawdef)
 	end
 end
 
-nodecore.register_lode("Block", {
+nodecore.register_adamant("Block", {
 		type = "node",
 		description = "## Adamant",
 		tiles = {modname .. "_#.png"},
@@ -90,65 +90,11 @@ nodecore.register_lode("Block", {
 		crush_damage = 4
 	})
 
-nodecore.register_lode("Prill", {
+nodecore.register_adamant("Prill", {
 		type = "craft",
 		groups = {metal_prill = 1},
 		light_source = 1,
 		inventory_image = modname .. "_#.png^[mask:" .. modname .. "_mask_prill.png",
-	})
-
-local function replacestack(pos, alt)
-	local stack = nodecore.stack_get(pos)
-	if stack:is_empty() then stack = nil end
-	local node = minetest.get_node(pos)
-	local name = stack and stack:get_name() or node.name
-	local def = minetest.registered_items[name] or {}
-	alt = def["metal_alt_" .. alt]
-	if not alt then return nodecore.remove_node(pos) end
-	if stack then
-		local repl = ItemStack(alt)
-		local qty = stack:get_count()
-		if qty == 0 then qty = 1 end
-		repl:set_count(qty * repl:get_count())
-		nodecore.remove_node(pos)
-		return nodecore.item_eject(pos, repl)
-	else
-		nodecore.set_node(pos, {name = alt})
-		nodecore.fallcheck(pos)
-	end
-end
-
-nodecore.register_craft({
-		label = "adamant stack heating",
-		action = "cook",
-		touchgroups = {flame = 3},
-		duration = 30,
-		cookfx = true,
-		nodes = {{match = {metal_temper_cool = true, count = false}}},
-		after = function(pos) return replacestack(pos, "hot") end
-	})
-
-nodecore.register_craft({
-		label = "adamant stack annealing",
-		action = "cook",
-		touchgroups = {flame = 0},
-		duration = 120,
-		priority = -1,
-		cookfx = {smoke = true, hiss = true},
-		nodes = {{match = {metal_temper_hot = true, count = false}}},
-		after = function(pos) return replacestack(pos, "annealed") end
-	})
-
-nodecore.register_craft({
-		label = "adamant stack quenching",
-		action = "cook",
-		touchgroups = {flame = 0},
-		check = function(pos)
-			return nodecore.quenched(pos)
-		end,
-		cookfx = true,
-		nodes = {{match = {metal_temper_hot = true, count = false}}},
-		after = function(pos) return replacestack(pos, "tempered") end
 	})
 
 -- Because of how massive they are, forging a block is a hot-working process.

--- a/rake.lua
+++ b/rake.lua
@@ -29,7 +29,7 @@ local function mkonrake(toolcaps)
 end
 nodecore.lode_rake_function = mkonrake
 
-nodecore.register_lode("rake", {
+nodecore.register_adamant("rake", {
 		type = "tool",
 		description = "## Adamant Rake",
 		inventory_image = modname .. "_#.png^[mask:nc_lode_rake.png",

--- a/shafts.lua
+++ b/shafts.lua
@@ -5,7 +5,7 @@ local minetest, nodecore
 
 local modname = minetest.get_current_modname()
 
-nodecore.register_lode("Bar", {
+nodecore.register_adamant("Bar", {
 		["type"] = "node",
 		description = "## Adamant Bar",
 		drawtype = "nodebox",
@@ -65,7 +65,7 @@ nodecore.register_craft({
 		}
 	})
 
-nodecore.register_lode("Rod", {
+nodecore.register_adamant("Rod", {
 		["type"] = "node",
 		description = "## Adamant Rod",
 		drawtype = "nodebox",

--- a/tools.lua
+++ b/tools.lua
@@ -15,14 +15,14 @@ local function toolhead(name, groups, prills)
 		return nodecore.toolcaps(t)
 	end
 
-	nodecore.register_lode("toolhead_" .. n, {
+	nodecore.register_adamant("toolhead_" .. n, {
 			type = "craft",
 			description = "## Adamant " .. name .. " Head",
 			inventory_image = modname .. "_#.png^[mask:nc_adamant_toolhead_" .. n .. ".png",
 			stack_max = 1
 		})
 
-	nodecore.register_lode("tool_" .. n, {
+	nodecore.register_adamant("tool_" .. n, {
 			type = "tool",
 			description = "## Adamant " .. name,
 			inventory_image = ("nc_lode_tempered.png^[mask:nc_adamant_mask_tool_handle.png^(" ..


### PR DESCRIPTION
This fixes a known item deletion bug discovered on VE-NC on 2021-12-05 where any metal prills cooling inside a storebox deleted the storebox.  Vanilla NC Lode was affected as well because Adamant replaced key components of the Lode API with older versions.

This may also fix other future or undiscovered bugs that would otherwise be caused by Adamant partially overwriting API or recipes from Lode.